### PR TITLE
Updates submodule references for ARC account

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,7 +16,7 @@
 	branch = feature/xcode9
 [submodule "DMSSDK"]
 	path = DMSSDK
-url=https://github.com/3sidedcube/dmssdk-ios-framework.git
+url=https://github.com/AmericanRedCross/dmssdk-ios-framework.git
 	branch = develop
 [submodule "SwipeCellKit"]
 	path = SwipeCellKit

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Each feature of the app is split into its own directory. The core view controlle
 
 ## Pre-requisites
 
-This project requires the [DMSDK](https://github.com/3sidedcube/dmssdk-ios-framework/) to function, this can be located in the `DMSSDK` folder.
+This project requires the [DMSDK](https://github.com/AmericanRedCross/dmssdk-ios-framework/) to function, this can be located in the `DMSSDK` folder.
 
 Xcode 9.0 or higher is required to run this project
 


### PR DESCRIPTION
I've updated the submodule references to point at the ARC version of DMSSDK on the latest commit and updated the readme to reflect the new location.